### PR TITLE
Check compilation warnings in `lint` instead of `test` phase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,6 @@ jobs:
       - checkout
       - restore_mix_cache
       - run: mix deps.get
-      - run: mix compile --force --warnings-as-errors
       - save_cache:
           key: mix-cache-{{ arch }}-{{ .Branch }}-{{ checksum "mix.lock" }}
           paths: ["deps", "_build"]
@@ -40,7 +39,7 @@ jobs:
       - restore_mix_cache
       - run: mix deps.get
       - run: mix format --check-formatted
-      - run: mix compile
+      - run: mix compile --force --warnings-as-errors
       - run: mix credo
       - run: mix docs && mix docs 2>&1 | (! grep -q "warning:")
       - run: asdf current elixir | awk '{print $2}' > .elixir_version


### PR DESCRIPTION
This way we can get rid of `mix compile` step in `test` phase as `mix test` compiles files autmatically. 
Consider scenario when we have multiple test pahses e.g. `test` `integration_test` `integration_test_with_some_options`. Now we don't have to write `mix compile --force --warnings-as-errors` in each of these steps.