### PR TITLE
Add a `publish` workflow, which publishes the package on hex.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,24 +6,16 @@ workflows:
   version: 2
   build:
     jobs:
-      - elixir/build_test
-      - elixir/test
-      - elixir/lint
-
-  publish:
-    jobs:
       - elixir/build_test:
-          filters: &filters-publish  # this yaml anchor allows for reusing this filter set elsewhere
-            branches:
-              ignore: /.*/
+          filters: &filters
             tags:
               only: /v.*/
       - elixir/test:
           filters:
-            <<: *filters-publish  # calling the anchor
+            <<: *filters
       - elixir/lint:
           filters:
-            <<: *filters-publish
+            <<: *filters
       - elixir/hex_publish:
           requires:
             - elixir/build_test
@@ -32,4 +24,7 @@ workflows:
           context:
             - Deployment
           filters:
-            <<: *filters-publish
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  elixir: membraneframework/elixir@1.2
+  elixir: membraneframework/elixir@1
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  elixir: membraneframework/elixir@1
+  elixir: membraneframework/elixir@1.2
 
 workflows:
   version: 2
@@ -9,3 +9,27 @@ workflows:
       - elixir/build_test
       - elixir/test
       - elixir/lint
+
+  publish:
+    jobs:
+      - elixir/build_test:
+          filters: &filters-publish  # this yaml anchor allows for reusing this filter set elsewhere
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v.*/
+      - elixir/test:
+          filters:
+            <<: *filters-publish  # calling the anchor
+      - elixir/lint:
+          filters:
+            <<: *filters-publish
+      - elixir/hex_publish:
+          requires:
+            - elixir/build_test
+            - elixir/test
+            - elixir/lint
+          context:
+            - Deployment
+          filters:
+            <<: *filters-publish


### PR DESCRIPTION
This workflow only executes on git tag pushes, where the tag fits the regex `v.*`.

Important: this should only be merged after the new orb is published, since it specifies orb version 1.2, which doesn't exist yet.